### PR TITLE
Add deleteAll function to Multimap.

### DIFF
--- a/library/STMContainers/Multimap.hs
+++ b/library/STMContainers/Multimap.hs
@@ -8,6 +8,7 @@ module STMContainers.Multimap
   newIO,
   insert,
   delete,
+  deleteAll,
   lookup,
   focus,
   null,
@@ -85,6 +86,12 @@ delete v k (Multimap m) =
           returnDecision Focus.Keep
       where
         returnDecision c = return ((), c)
+
+-- |
+-- Delete all values associated with a key.
+{-# INLINEABLE deleteAll #-}
+deleteAll :: Key k => k -> Multimap k v -> STM ()
+deleteAll k (Multimap m) = k `delete` m
 
 -- |
 -- Focus on an item with a strategy by a value and a key.


### PR DESCRIPTION
Hello,
I've been using this very useful library for a current project of mine. While using it, I've found the need for this particular function and implemented it within my fork. It's a very simple change, but something that otherwise must inefficiently without it. I understand if you'd like to maintain the interface as-is for simplicity's sake.

Additionally, this may need a version bump along with the changes mentioned in the patch.

Thanks