### PR TITLE
update to support GHC 8.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 env:
-  - ghc=7.6.1  cabal=1.18 lower_bound_dependencies=1
   - ghc=7.8.1  cabal=1.18
   - ghc=7.10.1 cabal=1.22
   - ghc=8.0.1  cabal=1.24 benchmarks=1 tests=1
+  - ghc=8.2.1  cabal=2.0
   
 install:
   # Set up the Shell to treat the semicolon as &&

--- a/executables/WordArrayTests/Update.hs
+++ b/executables/WordArrayTests/Update.hs
@@ -72,5 +72,5 @@ interpretMaybeList (Update u) =
       f
 
 wordSize :: Int
-wordSize = bitSize (undefined :: Word)
+wordSize = finiteBitSize (undefined :: Word)
 

--- a/library/STMContainers/WordArray/Indices.hs
+++ b/library/STMContainers/WordArray/Indices.hs
@@ -44,7 +44,7 @@ null = (== 0)
 
 {-# INLINE maxSize #-}
 maxSize :: Int
-maxSize = bitSize (undefined :: Indices)
+maxSize = finiteBitSize (undefined :: Indices)
 
 {-# INLINE fromList #-}
 fromList :: [Index] -> Indices

--- a/stm-containers.cabal
+++ b/stm-containers.cabal
@@ -69,7 +69,7 @@ library
     -- general:
     primitive >= 0.5 && < 0.7,
     base-prelude < 2,
-    base < 5
+    base >= 4.7 && < 6
   default-extensions:
     Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFoldable, DeriveFunctor, DeriveGeneric, DeriveTraversable, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, LambdaCase, LiberalTypeSynonyms, MagicHash, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators, UnboxedTuples
   default-language:
@@ -86,6 +86,9 @@ test-suite word-array-tests
     WordArrayTests.hs
   other-modules:
     WordArrayTests.Update
+    STMContainers.Prelude
+    STMContainers.WordArray
+    STMContainers.WordArray.Indices
   build-depends:
     -- testing:
     free >= 4.6 && < 5,


### PR DESCRIPTION
all new warnings squelched
all tests pass
this patch drops support for GHC 7.6 due to bitSize -> finiteBitSize