### PR TITLE
Update for GHC 9.6

### DIFF
--- a/test/Suites/Map/Update.hs
+++ b/test/Suites/Map/Update.hs
@@ -36,7 +36,7 @@ instance (Show k, Show v, Show c) => Show (UpdateF k v c) where
     where
       showsPrecInner = showsPrec (succ 5)
 
-instance Show1 (UpdateF k v) where
+instance (Show k, Show v) => Show1 (UpdateF k v) where
   liftShowsPrec = undefined
 
 makeFree ''UpdateF


### PR DESCRIPTION
In GHC 9.6, `Show1` has a quantified constraint: https://hackage.haskell.org/package/base-4.18.0.0/docs/Data-Functor-Classes.html#t:Show1